### PR TITLE
Moved @types/debug and snyk packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,8 @@
   },
   "private": false,
   "dependencies": {
-    "@types/debug": ">=4.1.0",
     "debug": ">=4.1.0",
-    "serialize-error": ">=5.0.0",
-    "snyk": "^1.321.0"
+    "serialize-error": ">=5.0.0"
   },
   "peerDependencies": {
     "@middy/core": ">=1.0.0"
@@ -63,6 +61,7 @@
     "@semantic-release/npm": "^7.0.0",
     "@semantic-release/release-notes-generator": "^9.0.0",
     "@types/aws-lambda": "^8.10.51",
+    "@types/debug": ">=4.1.0",
     "@types/http-errors": "^1.6.3",
     "@types/jest": "^25.1.0",
     "@types/supertest": "^2.0.7",
@@ -82,6 +81,7 @@
     "serverless": "^1.37.1",
     "serverless-offline": "^6.1.1",
     "serverless-webpack": "^5.2.0",
+    "snyk": "^1.321.0",
     "source-map-support": "^0.5.10",
     "supertest": "^4.0.2",
     "ts-jest": "^25.0.0",


### PR DESCRIPTION
We use the middleware in a lambda function which is packaged with webpack, but because these packages are in the dependencies we got a lot of snyk packages in the lambda function. Also didn't see any usage of snyk in de code and the debug types should be in devDeps.