### PR TITLE
feat: add Content-Type header

### DIFF
--- a/src/JSONErrorHandlerMiddleware.spec.ts
+++ b/src/JSONErrorHandlerMiddleware.spec.ts
@@ -48,6 +48,19 @@ describe('JSONErrorHandlerMiddleware', () => {
         await JSONErrorHandlerMiddleware().onError(handler)
         expect(JSON.parse((handler.response as any).body).stack).toBeUndefined()
       })
+
+      it('adds Content-Type header', async () => {
+        const handler = {
+          callback: jest.fn(),
+          context: {} as Context,
+          error: createHttpError(statusCode, 'Oops'),
+          event: {},
+          internal: {},
+          response: {}
+        }
+        await JSONErrorHandlerMiddleware().onError(handler)
+        expect((handler.response as any).headers["Content-Type"]).toBe('application/json')
+      })
     })
 
     describe('with errors wit status code 500', () => {
@@ -80,6 +93,19 @@ describe('JSONErrorHandlerMiddleware', () => {
           message: 'Internal server error',
           statusCode: 500
         })
+      })
+
+      it('adds Content-Type header', async () => {
+        const request = {
+          callback: jest.fn(),
+          context: {} as Context,
+          error: createHttpError(statusCode, 'Oops'),
+          event: {},
+          internal: {},
+          response: {}
+        }
+        await JSONErrorHandlerMiddleware().onError(request)
+        expect((request.response as any).headers["Content-Type"]).toBe('application/json')
       })
     })
   })

--- a/src/JSONErrorHandlerMiddleware.ts
+++ b/src/JSONErrorHandlerMiddleware.ts
@@ -2,6 +2,7 @@
  * # JSON Error Handler Middleware
  */
 /** An additional comment to make sure Typedoc attributes the comment above to the file itself */
+import { APIGatewayProxyResult } from 'aws-lambda'
 import debugFactory, { IDebugger } from 'debug'
 import { MiddlewareObj } from '@middy/core'
 import { serializeError } from 'serialize-error'
@@ -17,6 +18,14 @@ interface Request<TEvent = any, TResult = any, TErr = Error> {
   internal: {
     [key: string]: any
   }
+}
+
+function addContentTypeHeader(response: APIGatewayProxyResult): void {
+  if (!response.headers) {
+    response.headers = {}
+  }
+
+  response.headers['Content-Type'] = 'application/json'
 }
 
 /** The actual middleware */
@@ -45,6 +54,7 @@ export class JSONErrorHandlerMiddleware
         body: JSON.stringify(omit(['stack'], serializeError(error))),
         statusCode: error.statusCode
       }
+      addContentTypeHeader(request.response)
       return
     }
     this.logger('Responding with internal server error')
@@ -55,6 +65,7 @@ export class JSONErrorHandlerMiddleware
       }),
       statusCode: 500
     }
+    addContentTypeHeader(request.response)
     return
   };
 }


### PR DESCRIPTION
Since the output is serialized to JSON it makes sense to always add Content-Type: application/json header to follow the specs.

<!-- Please only open PRs for issues in place. If there is no issue, please open the issue first. Then create this PR and link it to the issue by adding the issue number in the line below. -->
Closes #67

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

<!-- If you wrote meaningful commit messages, this is it. If you don't feel confident that your commit messages fully explain your changes and your reasoning behind it, then you can add more information to this PR. Or, even better, update your commit messages ;) -->
